### PR TITLE
Fix to avoid premature exit

### DIFF
--- a/fcopy.c
+++ b/fcopy.c
@@ -49,6 +49,9 @@ void zero_copy(const char *src_path, const char *dst_path)
     exit(1);
   }
 
+  // Sync to avoid dirty memory
+  fdatasync(dst);
+
   close(dst);
   close(src);
 }


### PR DESCRIPTION
Hi!

You should sync with the destination to avoid wrong measurement results.

No sync:
./fcopy /tmp/rbigfile.dat /tmp/wbigfile2.dat 2  0.00s user 0.24s system 99% cpu 0.242 total

0.242 seconds for a 1 GB file on a ~180MB/s hard disk...

grep Dirty /proc/meminfo
Dirty:           1048476 kB

There we go, dirty memory that isn't flushed yet to the disk!

After adding the fdatasync call:
./fcopy /tmp/rbigfile.dat /tmp/wbigfile2.dat 2  0.00s user 0.32s system 4% cpu 6.461 total

Regards!
